### PR TITLE
3 feature playlistpage hadil

### DIFF
--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -71,7 +71,7 @@ Maak voor elke pagina, of onderdeel, een ontwerp op basis van de huisstijl. (Bij
 
 ### Code afspraken
 Maak code afspraken met je team over de Node-code, (semantische) HTML, gestructureerde CSS en conventies.
-Denk na over de HTML structuur, en het voorkomen van layout shifts, toepassen van perceived performance en loading hints aan de browser en het toepassen van responsive images. Maak afspraken over de volgorde van de CSS, van generiek-naar-specifiek. Bedenk een goede volgorde in de Node en de routing. Maak afspraken over het schrijven van comments. Etc ..
+Denk na over de HTML structuur en nesting van elementen, en het voorkomen van layout shifts, toepassen van perceived performance en loading hints aan de browser en het toepassen van responsive images. Maak afspraken over de volgorde van de CSS, van generiek-naar-specifiek. Bedenk een goede volgorde in de Node en de routing. Maak afspraken over het schrijven van comments. Etc ..
 
 ## Bouwen
 In de bouwfase realiseer je de beslissingen uit de ontwerpfase. 

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -67,6 +67,7 @@ Bepaal welke pagina's jullie gaan ontwerpen en bouwen, welke url's daarbij horen
 ### Wireframe, Wireflow & Breakdown
 Schets per pagina en onderdelen gezamenlijk een wireframe en/of wireflow en maak een breakdown van de HTML, CSS en Client-side JS. Het is belangrijk om dit gezamenlijk te doen, nu maak je met het team afspraken over code, semantiek en naamgeving. 
 
+### Ontwerp
 Maak voor elke pagina, of onderdeel, een ontwerp op basis van de huisstijl. (Bijvoorbeeld in Figma) Dit wordt het ontwerp dat jullie gaan realiseren. Het ontwerp zal tijdens de werkzaamheden veranderen. Dat is prima. Soms zal je de veranderingen bijhouden in het Figma file, soms is dat niet nodig. 
 
 ### Code afspraken

--- a/public/styles.css
+++ b/public/styles.css
@@ -467,6 +467,7 @@ body {
           transition: .3s linear;
         }
 
+
       /* add playlist styling-article */
       > article:nth-of-type(1) {
         background: linear-gradient(135deg, rgba(255, 255, 255, 0.418), rgba(124, 90, 196, 0.304));
@@ -1135,6 +1136,117 @@ body {
 }
 
 /* ----------------------------------------------------------------- */
+
+/* all playlist page */
+
+.back-icon {
+  position: absolute;
+  top: 5.5em;
+  left: 1em;
+}
+
+.allplaylist {
+  align-items: center;
+  background-color: rgb(0, 0, 0);
+  color: var(--white);
+  overflow-y: hidden;
+  width: 100%; 
+  background-image:
+  radial-gradient(at 84% 13%, hsla(259,47%,56%,1) 0px, transparent 50%),
+  radial-gradient(at 21% 74%, hsla(265,76%,27%,1) 0px, transparent 50%);
+}
+
+header {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: auto;
+  width: 100%;
+}
+
+.all-playlist {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+
+  article {
+    background: linear-gradient(45deg, #1982c4, #8712ab);
+    position: relative;
+    cursor: pointer;
+    z-index: 0;
+    border-radius: 183px 78px 200px 136px;
+    height: 21em;
+    width: 15em;
+    margin: 3em;
+  }
+}
+    
+.all-playlist article::before {
+  content: '';
+  position: absolute;
+  top: 0; 
+  right: 0; 
+  bottom: 0; 
+  left: 0; 
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(45deg, #1982c4, #8712ab, #ff009d, #ff6600, #ffcc00, #00cc99);
+  animation: border 4s linear infinite;
+}
+
+@keyframes border {
+  0%,
+  100% {
+    background: linear-gradient(45deg, #1982c4, #8712ab, #ff009d, #ff6600, #ffcc00, #00cc99);
+  }
+  50% {
+    background: linear-gradient(225deg, #1982c4, #8712ab, #ff009d, #ff6600, #ffcc00, #00cc99);
+  }
+}
+
+.background-picture img {
+  filter: blur(5px);
+  height: 20em;
+  width: 15em;
+  border-radius: 183px 78px 200px 136px;
+  opacity: 0.8;
+
+}
+
+.playlist-img {
+  height: 15em;
+  position: absolute;
+  bottom: 0.8em;
+  left: 3em;
+  border-radius: 52px 169px 127px 179px;
+  -webkit-border-radius: 52px 169px 127px 179px;
+  -moz-border-radius: 52px 169px 127px 179px;
+}
+
+.playlist-details {
+  padding: 1em;
+  border-radius: var(--radius-2);
+  transform: skew(-0.06turn);
+  rotate: -20deg;
+  width: max-content;
+  position: absolute;
+  top: 80%;
+  right: -20%;
+  background: linear-gradient(135deg, rgba(120, 117, 117, 0.555), rgba(97, 9, 119, 0.675));
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--method-1-d2);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+
+  p {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+
 /* styling allstories-page */
 .allstories {
   align-items: center;
@@ -1142,8 +1254,8 @@ body {
   flex-direction: column;
   overflow-y: hidden;
   width: 100%;
-
   background-color: hsla( 0, 0%, 0%,1);
   color: var(--white);
 }
+
 

--- a/server.js
+++ b/server.js
@@ -60,6 +60,16 @@ app.get('/lessons', function (request, response) {
   })
 })
 
+app.get('/allplaylist', function (request, response) {
+  Promise.all([
+    fetchJson('https://fdnd-agency.directus.app/items/tm_playlist?fields=*,image.id,image.height,image.width'),
+    fetchJson('https://fdnd-agency.directus.app/items/tm_language'),
+  ]).then(([playlistData, languageData]) => {
+    response.render('allplaylist', {playlist: playlistData.data,language: languageData.data })
+  })
+})
+
+
 app.get('/allstories', function (request, response) {
   Promise.all([
     fetchJson('https://fdnd-agency.directus.app/items/tm_story?fields=*,image.id,image.height,image.width'),

--- a/views/allplaylist.ejs
+++ b/views/allplaylist.ejs
@@ -1,0 +1,46 @@
+<%- include('./partials/head') %>
+<%- include('./partials/navigation', {current: '/lessons'}); %>
+<main class="allplaylist">
+
+    <a href="/lessons"><svg class="back-icon" version="1.0" xmlns="http://www.w3.org/2000/svg"width="36" height="30" viewBox="0 0 512.000000 512.000000"preserveAspectRatio="xMidYMid meet"><g transform="translate(0.000000,512.000000) scale(0.100000,-0.100000)" fill="#fff" stroke="none"><path d="M2391 3364 c-435 -438 -791 -800 -791 -804 0 -12 1581 -1600 1594 -1600 14 0 326 311 326 325 0 6 -285 295 -632 642 l-633 633 633 633 c347 347 632 637 632 642 0 14 -313 325 -327 325 -6 0 -367 -358 -802 -796z"/></g></svg></a>
+
+    <header>
+        <h1>All playlist</h1>
+    </header>
+
+    <section class="all-playlist">
+        <% playlist.forEach(playlist => { %>
+                <article>
+                <% if (playlist.image) { %>
+
+                    <picture class="background-picture">
+                        <source srcset="https://fdnd-agency.directus.app/assets/<%= playlist.image.id %>?format=avif" type="images/avif">
+                        <source srcset="https://fdnd-agency.directus.app/assets/<%= playlist.image.id %>?format=webp" type="images/webp">
+                        
+                        <img src="https://fdnd-agency.directus.app/assets/<%= playlist.image.id %>" width="<%= playlist.image.width %>" height="<%= playlist.image.height %>"  alt="playlist">
+                    
+                    </picture>
+        
+                    <picture>
+                        <source srcset="https://fdnd-agency.directus.app/assets/<%= playlist.image.id %>?format=avif" type="images/avif">
+                        <source srcset="https://fdnd-agency.directus.app/assets/<%= playlist.image.id %>?format=webp" type="images/webp">
+                        
+                        <img class="playlist-img" src="https://fdnd-agency.directus.app/assets/<%= playlist.image.id %>" width="<%= playlist.image.width %>" height="<%= playlist.image.height %>"  alt="playlist">
+                    
+                    </picture>
+        
+                <% }  else { %> 
+                    <img class="playlist-img" src="./Placeholder-1.png" width="448" height="380" alt="playlist"> 
+                <% } %>
+                
+                    <div class="playlist-details">
+                        <h5><%= playlist.title %></h5>        
+                        <p>31 min. 55sec <%- include('./partials/svg-play') %></p>
+                
+                    </div>
+                </article>
+            <% }) %>
+    </section>
+</main>
+
+<%- include('./partials/foot') %>

--- a/views/lessons.ejs
+++ b/views/lessons.ejs
@@ -14,7 +14,7 @@
     <section class="own-playlist">
         <div><div class="header-own-playlist">
             <h2>Own <br> play <br> list</h2>
-            <a href="/allstories"><p>Show all playlist</p></a></div>
+            <a href="/allplaylist"><p>Show all playlist</p></a></div>
         
             <div class="playlist-carousel">
                 <article>


### PR DESCRIPTION
## All playlist page
Op de lessonspagina zijn maar een paar playlists te zien. Daarom heb ik een nieuwe pagina aangemaakt waar alle playlists zichtbaar zijn. Het is nu overzichtelijker en de gebruiker kan makkelijk een playlist kiezen.

<img src="https://github.com/lisavanmansom/pleasurable-ui/assets/144008714/af1ec78d-e22c-4bbf-8325-95bbbc6aa02b" width="400px">

### Playlist page schets
Het design komt vrijwel overheen met de originele schets, ik heb alleen de vormen van de afbeeldingen aangepast en een moving border toegevoegd.

<img src="https://github.com/lisavanmansom/pleasurable-ui/assets/144008714/f5e042c5-c4a1-4c58-987f-68697db35f3d" height="400px">

### Code

- [CSS](https://github.com/lisavanmansom/pleasurable-ui/blob/8a9b1d8fc575bec1e8a191ee53a26745904ffe93/public/styles.css#L1140-L1247)
- [EJS](https://github.com/lisavanmansom/pleasurable-ui/blob/3-feature-playlistpage-hadil/views/allplaylist.ejs)

### Codeconventies 
Door de code te nesten heb ik me aan de [codeconventies](https://github.com/Hadil24A/Pleasurable-UI/wiki/Week-1#code-conventies) gehouden.

```
.playlist-details {
  padding: 1em;
  border-radius: var(--radius-2);
  transform: skew(-0.06turn);
  rotate: -20deg;
  width: max-content;
  position: absolute;
  top: 80%;
  right: -20%;
  background: linear-gradient(135deg, rgba(120, 117, 117, 0.555), rgba(97, 9, 119, 0.675));
  backdrop-filter: blur(10px);
  -webkit-backdrop-filter: blur(10px);
  border: 1px solid var(--method-1-d2);
  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);

  p {
    display: flex;
    flex-direction: row;
    justify-content: space-between;
  }
}
```

